### PR TITLE
Fix typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import Img from 'gatsby-image'
 import { getFluidGatsbyImage } from 'gatsby-storyblok-image'
 
 const FluidImage = ({ blok }) => {
-  const fluidProps = getFixedGatsbyImage(blok.image, {
+  const fluidProps = getFluidGatsbyImage(blok.image, {
     maxWidth: 900
   })
 


### PR DESCRIPTION
This fixes a wrongly used method name in the docs for the fluid image example.