### PR TITLE
Updated regex to allow uppercase chars in extension

### DIFF
--- a/src/utils/getBasicImageProps.js
+++ b/src/utils/getBasicImageProps.js
@@ -1,4 +1,4 @@
-const validImageUrlPattern = /^\/\/a.storyblok.com\/f\/[0-9]+\/[0-9]+x[0-9]+\/[A-Za-z0-9]+\/[\S]+\.[a-z]+/
+const validImageUrlPattern = /^\/\/a.storyblok.com\/f\/[0-9]+\/[0-9]+x[0-9]+\/[A-Za-z0-9]+\/[\S]+\.[A-Za-z]+/
 
 function getBasicImageProps(image) {
   let url = null


### PR DESCRIPTION
The `validImageUrlPattern` regex in its current form, will not pass if there are uppercase characters in the filename.

Uppercase filenames may be bad practice/invalid, however my use case was a photo that was taken on a iPhone/iOS, which when uploaded to storyblok, has an uppercase `JPG` extension, instead of the 'expected' lowercase `jpg`. 

Storyblok will also correctly serve this image from their CDN, with the uppercase extension.

This seems like enough of a reason to allow uppercase filenames to be 'valid' within the plugin.
I've just updated the regex to allow uppercase and lowercase characters in the extension - similar to the filename. 

There could be an argument for making the entire regular expression case insensitive (by adding the `i` flag), but that could cause some false positives, so I just modified the extension for the time being.