### PR TITLE
Fix images URLs with https

### DIFF
--- a/src/utils/getBasicImageProps.js
+++ b/src/utils/getBasicImageProps.js
@@ -13,6 +13,7 @@ function getBasicImageProps(image) {
     lqip = image.base64 ? image.base64 : null
   }
 
+  url = url.replace('https:', '')
   url = validImageUrlPattern.test(url) ? url : null
 
   if (!url) {


### PR DESCRIPTION
Storyblok's image assets add "https://" to URLs, and there's no way to disable that (like it is possible with "Image (old)" field type), as result - such images aren't displayed. This line fixes that, possibly there is a more elegant solution.