### PR TITLE
fix: allows uppercase extension in filename

### DIFF
--- a/src/utils/getBasicImageProps.js
+++ b/src/utils/getBasicImageProps.js
@@ -1,4 +1,4 @@
-const validImageUrlPattern = /^(https?:)?\/\/a.storyblok.com\/f\/[0-9]+\/[0-9]+x[0-9]+\/[A-Za-z0-9]+\/[\S]+\.[a-z]+/
+const validImageUrlPattern = /^(https?:)?\/\/a.storyblok.com\/f\/[0-9]+\/[0-9]+x[0-9]+\/[A-Za-z0-9]+\/[\S]+\.[a-zA-Z]+/
 
 function getBasicImageProps(image) {
   let url = null


### PR DESCRIPTION
Solving ticket: #23 

currently validImageUrlPattern allows only file with lowercase extension. some of the assets are uploaded with uppercase (eg. PNG) and the plugin doesn't treat them as valid

### Change
changes extension regex from `\.[a-z]/` to `\.[a-zA-Z]/`